### PR TITLE
ci: Do not generate Release notes

### DIFF
--- a/.github/workflows/release-formigas_fastlane_cd.yaml
+++ b/.github/workflows/release-formigas_fastlane_cd.yaml
@@ -89,5 +89,4 @@ jobs:
         uses: ncipollo/release-action@v1.14.0
         with:
           tag: formigas_fastlane_cd-${{ github.event.inputs.version }}
-          generateReleaseNotes: true
-          makeLatest: true
+          makeLatest: false

--- a/.github/workflows/release-formigas_feature.yaml
+++ b/.github/workflows/release-formigas_feature.yaml
@@ -89,5 +89,4 @@ jobs:
         uses: ncipollo/release-action@v1.14.0
         with:
           tag: formigas_feature-${{ github.event.inputs.version }}
-          generateReleaseNotes: true
-          makeLatest: true
+          makeLatest: false


### PR DESCRIPTION
Before commits for different bricks would be mixed together.